### PR TITLE
Add KakaoSDK adapter null check for preventing crash

### DIFF
--- a/app/src/main/java/gun0912/com/kakaologin/MainActivity.java
+++ b/app/src/main/java/gun0912/com/kakaologin/MainActivity.java
@@ -30,8 +30,10 @@ public class MainActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
         ButterKnife.bind(this);
-        KakaoSDK.init(new LoginKakaoActivity.KakaoSDKAdapter());
 
+        if(KakaoSDK.getAdapter() == null) {
+            KakaoSDK.init(new LoginKakaoActivity.KakaoSDKAdapter());
+        }
 
     }
 


### PR DESCRIPTION
Sometimes, KakaoSDK make some crash error. KAKAO corporation recommend to add adapter null checking before calling init method. 
